### PR TITLE
Fix Friends: extend LocalStorage pages for WAL beyond EOF

### DIFF
--- a/FindMySyncPlus/LocalStorageDecryptor.swift
+++ b/FindMySyncPlus/LocalStorageDecryptor.swift
@@ -99,8 +99,15 @@ actor LocalStorageDecryptor {
             let start = i * Self.pageSize
             return Data(dbData[start..<start + Self.pageSize])
         }
-        for (idx, pageData) in walPages {
-            guard idx >= 0 else { continue }
+        // `parseWAL` reads `pgno` as an unvalidated UInt32, so a garbage frame could
+        // drive the growth loop toward appending terabytes of pages. A WAL cannot
+        // legitimately add more pages than it has frames, so that is a safe ceiling;
+        // out-of-range frames are dropped and the caller surfaces `.dbCorrupted`.
+        // Sorting keeps growth strictly append-forward — `Dictionary` iteration order
+        // is nondeterministic, which would otherwise make failures unreproducible.
+        let maxPages = pageCount + walPages.count
+        for (idx, pageData) in walPages.sorted(by: { $0.key < $1.key }) {
+            guard idx >= 0, idx < maxPages else { continue }
             while idx >= encPages.count {
                 encPages.append(Data(count: Self.pageSize))
             }

--- a/FindMySyncPlus/LocalStorageDecryptor.swift
+++ b/FindMySyncPlus/LocalStorageDecryptor.swift
@@ -91,15 +91,20 @@ actor LocalStorageDecryptor {
         // Parse WAL if present
         let walPages = parseWAL(walURL)
 
-        // Build encrypted page array, merging WAL overrides
+        // Build encrypted page array, merging WAL overrides.
+        // LocalStorage.db is often a single page with the real content in the WAL —
+        // extend the page array when WAL frames reference pages beyond EOF
+        // (same approach as findmy-key-extractor's decrypt_localstorage.py).
         var encPages: [Data] = (0..<pageCount).map { i in
             let start = i * Self.pageSize
             return Data(dbData[start..<start + Self.pageSize])
         }
         for (idx, pageData) in walPages {
-            if idx < encPages.count {
-                encPages[idx] = pageData
+            guard idx >= 0 else { continue }
+            while idx >= encPages.count {
+                encPages.append(Data(count: Self.pageSize))
             }
+            encPages[idx] = pageData
         }
 
         // Verify key by decrypting page 0


### PR DESCRIPTION
Fixes the Friends error `database disk image is malformed` when `LocalStorage.db` is tiny and almost everything is in the WAL (common on recent macOS).

Same root cause as #13 — that issue was closed after a rebuild, but the WAL merge still dropped pages past EOF. No existing PR for this.

### Change
When applying WAL frames, grow the encrypted page array instead of only updating pages that already exist in the main file (same approach as findmy-key-extractor).

### Tested on
macOS 26.5.2 (25F84), Apple Silicon — main DB was 1 page / ~4KB with a multi‑MB WAL; decrypt + friends query OK after this fix.